### PR TITLE
Command !commands

### DIFF
--- a/sql/list_commands.sql
+++ b/sql/list_commands.sql
@@ -1,0 +1,1 @@
+SELECT command FROM templates WHERE channel = ?;


### PR DESCRIPTION
Pretty basic command that allows users to send `!commands` in chat and receive a list of all the commands registered for that specific channel.

A nice-to-have might be to sort the commands by name, either using a `SORT BY command ...` or by sorting the `Vec<&str>` before the `.join`.

NOTE: the `!` are prepended to the command names in the `.join` and in the final `format!` which is faster:tm: but also slightly confusing and considering we're talking microseconds vs nanoseconds it might just not be worth it.